### PR TITLE
[clang-format] Inheritance lists are now aligned with the colon if th…

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1063,9 +1063,14 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
   if (PreviousNonComment && PreviousNonComment->is(TT_InheritanceColon) &&
       Style.BreakInheritanceList == FormatStyle::BILS_AfterColon)
     return State.Stack.back().Indent;
-  if (NextNonComment->isOneOf(TT_CtorInitializerColon, TT_InheritanceColon,
-                              TT_InheritanceComma))
+  if (NextNonComment->isOneOf(TT_CtorInitializerColon, TT_InheritanceColon))
     return State.FirstIndent + Style.ConstructorInitializerIndentWidth;
+  if (NextNonComment->is(TT_InheritanceComma)) {
+    return State.Stack.back().Indent -
+           (PreviousNonComment ? PreviousNonComment->ColumnWidth +
+                                     PreviousNonComment->SpacesRequiredBefore
+                               : 0);
+  }
   if (Previous.is(tok::r_paren) && !Current.isBinaryOperator() &&
       !Current.isOneOf(tok::colon, tok::comment))
     return ContinuationIndent;


### PR DESCRIPTION
…ey break before the comma or with the access specifier/identifier if they break before the colon.